### PR TITLE
Fix: object in dict not found exception on first try

### DIFF
--- a/restexample-windows.yml
+++ b/restexample-windows.yml
@@ -57,7 +57,7 @@
       url: "http://localhost:8080/swagger-ui.html"
       method: GET
     register: result
-    until: result.status_code == 200  
+    until: result.status_code is defined and result.status_code == 200 
     retries: 5
     delay: 5
 


### PR DESCRIPTION
This exception was thrown with ansible 2.4.2.0 and python 2.7.14